### PR TITLE
Scala object serializer supports copying.

### DIFF
--- a/core/src/main/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializer.scala
+++ b/core/src/main/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializer.scala
@@ -29,6 +29,12 @@ import scala.util.control.Exception.allCatch
 class ScalaObjectSerializer[T] extends Serializer[T] {
   private val cachedObj = MMap[Class[?], Option[T]]()
 
+  // NOTE: even if a standalone or companion Scala object contains mutable
+  // fields, the fact that there is only one of them in a process means that
+  // we don't want to make a copy, so this serializer's type is treated as
+  // always being immutable.
+  override def isImmutable: Boolean = true
+
   // Does nothing
   override def write(kser: Kryo, out: Output, obj: T): Unit = ()
 

--- a/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
+++ b/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
@@ -1,6 +1,5 @@
 package io.altoo.serialization.kryo.scala.serializer
 
-import io.altoo.serialization.kryo.scala.serializer
 import io.altoo.serialization.kryo.scala.testkit.AbstractKryoTest
 
 object standalone
@@ -8,15 +7,27 @@ object standalone
 object ScalaObjectSerializerTest
 
 class ScalaObjectSerializerTest extends AbstractKryoTest {
+  private def configureKryo(): Unit = {
+    kryo.setRegistrationRequired(false)
+    kryo.addDefaultSerializer(classOf[standalone.type], classOf[ScalaObjectSerializer[Any]])
+    kryo.addDefaultSerializer(classOf[ScalaObjectSerializerTest.type], classOf[ScalaObjectSerializer[Any]])
+  }
+
   behavior of "ScalaObjectSerializer"
 
   it should "round trip standalone and companion objects" in {
-    kryo.setRegistrationRequired(false)
-    kryo.addDefaultSerializer(classOf[standalone.type], classOf[ScalaObjectSerializer[Any]])
-    kryo.addDefaultSerializer(classOf[serializer.ScalaObjectSerializerTest.type], classOf[ScalaObjectSerializer[Any]])
+    configureKryo()
 
     testSerializationOf(standalone)
 
     testSerializationOf(ScalaObjectSerializerTest)
+  }
+
+  it should "support copying of standalone and companion objects" in {
+    configureKryo()
+
+    testCopyingOf(standalone)
+
+    testCopyingOf(ScalaObjectSerializerTest)
   }
 }

--- a/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
+++ b/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
@@ -2,9 +2,26 @@ package io.altoo.serialization.kryo.scala.serializer
 
 import io.altoo.serialization.kryo.scala.testkit.AbstractKryoTest
 
-object standalone
+import java.util.UUID
 
-object ScalaObjectSerializerTest
+trait Snowflake {
+  val state: UUID = UUID.randomUUID()
+
+  override def hashCode(): Int = state.hashCode()
+
+  override def equals(another: Any): Boolean = another match {
+    case anotherSnowflake: Snowflake =>
+      // NOTE: don't worry about respecting different flavours of
+      // subclass, as all snowflakes are constructed different from
+      // each other to start with. Only copies can be equal!
+      this.state == anotherSnowflake.state
+    case _ => false
+  }
+}
+
+object standalone extends Snowflake
+
+object ScalaObjectSerializerTest extends Snowflake
 
 class ScalaObjectSerializerTest extends AbstractKryoTest {
   private def configureKryo(): Unit = {
@@ -20,16 +37,16 @@ class ScalaObjectSerializerTest extends AbstractKryoTest {
   it should "round trip standalone and companion objects" in {
     configureKryo()
 
-    testSerializationOf(standalone)
+    (testSerializationOf(standalone) should be).theSameInstanceAs(standalone)
 
-    testSerializationOf(ScalaObjectSerializerTest)
+    (testSerializationOf(ScalaObjectSerializerTest) should be).theSameInstanceAs(ScalaObjectSerializerTest)
   }
 
   it should "support copying of standalone and companion objects" in {
     configureKryo()
 
-    testCopyingOf(standalone)
+    (testCopyingOf(standalone) should be).theSameInstanceAs(standalone)
 
-    testCopyingOf(ScalaObjectSerializerTest)
+    (testCopyingOf(ScalaObjectSerializerTest) should be).theSameInstanceAs(ScalaObjectSerializerTest)
   }
 }

--- a/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
+++ b/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
@@ -9,8 +9,10 @@ object ScalaObjectSerializerTest
 class ScalaObjectSerializerTest extends AbstractKryoTest {
   private def configureKryo(): Unit = {
     kryo.setRegistrationRequired(false)
-    kryo.addDefaultSerializer(classOf[standalone.type], classOf[ScalaObjectSerializer[Any]])
-    kryo.addDefaultSerializer(classOf[ScalaObjectSerializerTest.type], classOf[ScalaObjectSerializer[Any]])
+    // NOTE: to support building under Scala 2.12, use the Java approach of obtaining
+    // a singleton object's class at runtime, rather than `classOf[singleton.type]`
+    kryo.addDefaultSerializer(standalone.getClass, classOf[ScalaObjectSerializer[Any]])
+    kryo.addDefaultSerializer(ScalaObjectSerializerTest.getClass, classOf[ScalaObjectSerializer[Any]])
   }
 
   behavior of "ScalaObjectSerializer"

--- a/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
+++ b/core/src/test/scala/io/altoo/serialization/kryo/scala/serializer/ScalaObjectSerializerTest.scala
@@ -1,0 +1,22 @@
+package io.altoo.serialization.kryo.scala.serializer
+
+import io.altoo.serialization.kryo.scala.serializer
+import io.altoo.serialization.kryo.scala.testkit.AbstractKryoTest
+
+object standalone
+
+object ScalaObjectSerializerTest
+
+class ScalaObjectSerializerTest extends AbstractKryoTest {
+  behavior of "ScalaObjectSerializer"
+
+  it should "round trip standalone and companion objects" in {
+    kryo.setRegistrationRequired(false)
+    kryo.addDefaultSerializer(classOf[standalone.type], classOf[ScalaObjectSerializer[Any]])
+    kryo.addDefaultSerializer(classOf[serializer.ScalaObjectSerializerTest.type], classOf[ScalaObjectSerializer[Any]])
+
+    testSerializationOf(standalone)
+
+    testSerializationOf(ScalaObjectSerializerTest)
+  }
+}

--- a/core/src/test/scala/io/altoo/serialization/kryo/scala/testkit/AbstractKryoTest.scala
+++ b/core/src/test/scala/io/altoo/serialization/kryo/scala/testkit/AbstractKryoTest.scala
@@ -70,4 +70,12 @@ trait KryoSerializationTesting {
     input.close()
     obj1.asInstanceOf[T]
   }
+
+  protected final def testCopyingOf[T](obj: T): T = {
+    val copy = kryo.copy(obj)
+
+    assert(copy == obj)
+
+    obj
+  }
 }


### PR DESCRIPTION
This follows on from https://github.com/altoo-ag/akka-kryo-serialization/issues/297.

I've broken up the PR into three commits.

1. Add a test for the existing serialization / deserialization functionality provided by `ScalaObjectSerializer`.
2. Add a failing test to reproduce the problem with copying.
3. Make the failing test pass.